### PR TITLE
Added Share text

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Non-authenticated users can create pastes.
 - https://bin.bloerg.net
 - https://crypticbin.com
 - https://pastey.gg
+- https://www.primenotepad.com/share-text
   
 ## Authenticated Pastebins
 


### PR DESCRIPTION

<img width="1165" height="673" alt="image" src="https://github.com/user-attachments/assets/0baeb1d2-1ae0-4ce9-9cf1-826c16f1be6a" />
You can use PrimeNotepad Share Text like a temporary Pastebin service:

1. Go to https://www.primenotepad.com/share-text
2. Paste or type your text into the text box.
3. Choose how long you want the paste to remain available — 1 day, 1 week, or 1 month.
4. Click **Create Share Link**.
5. PrimeNotepad generates a unique shareable URL.
6. Copy that URL and send it to anyone you want to share the text with.

The recipient doesn't need an account or login. They can simply open the link and read the shared text.

It also generates a QR code, so you can share the text by scanning the QR code instead of sending the URL.

The main difference from a traditional Pastebin is that the links are temporary and automatically expire, so the shared content doesn't remain available permanently.

For example, you could paste a code snippet, troubleshooting instructions, meeting notes, or a temporary message, select **1 week**, create the link, and send that link to someone. After the selected expiration period, the shared content is no longer available.
